### PR TITLE
Setup and use local service-core to fix broken dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .project
 build
+dependencies
 dev-site.iml
 node_modules
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Source content for api.pryv.com (API reference, recommendations, guides, etc.)
 
 ### Prerequisites
 
-Node v4.4.3+.
+Node v8.3.0+, Yarn v0.21.3+
 
 `make setup` sets up the environment.
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Node v4.4.3+.
 
 `make setup` sets up the environment.
 
-### Build & publish
+**Note:** the setup command will install a dependency to pryv/service-core.
+By default, it will target the branch defined inside the setup script.
+If you want to use another branch, use `make setup core=my_branch` instead.
 
-Prerequisite: the source API server working copy must be under `../api-server`.
+### Build & publish
 
 - `make build` generates the website from the source into the `build` folder
 - `make watch` watches the source folder and rebuilds on changes

--- a/dev-env/setup.sh
+++ b/dev-env/setup.sh
@@ -10,16 +10,37 @@ cd $scriptsFolder/..
 hash git 2>&- || { echo >&2 "I require git."; exit 1; }
 hash yarn 2>&- || { echo >&2 "I require node and yarn."; exit 1; }
 
-echo "
-Installing Node modules from 'package.json' if necessary...
-"
+# resolve service-core dependency
+if [ ! -d dependencies/core ]
+then
+  echo "Setting up 'dependencies/core' folder for service-core dependency."
+  git clone git@github.com:pryv/service-core.git dependencies/core
+fi
+
+if [ -z "$1" ]
+then
+  # default branch used for service-core dependency
+  coreBranch="release-1.1"
+else
+  coreBranch=$1
+fi
+
+echo "Service-core dependency is targeting the following branch: $coreBranch"
+
+# ensure service-core dependency is up-to-date
+cd dependencies/core
+git checkout $coreBranch
+git pull
+cd $scriptsFolder/..
+
+# install node modules
+echo "Installing Node modules from 'package.json' if necessary."
 yarn install
 
+# setup build folder
 if [ ! -d build ]
 then
-  echo "
-Setting up 'build' folder for publishing to GitHub pages...
-"
+  echo "Setting up 'build' folder for publishing to GitHub pages."
   git clone git@github.com:pryv/pryv.github.io.git build
 fi
 

--- a/dev-env/setup.sh
+++ b/dev-env/setup.sh
@@ -20,7 +20,7 @@ fi
 if [ -z "$1" ]
 then
   # default branch used for service-core dependency
-  coreBranch="release-1.1"
+  coreBranch="release-1.2"
 else
   coreBranch=$1
 fi

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf build/*
 
 setup:
-	./dev-env/setup.sh
+	./dev-env/setup.sh $(core)
 
 retrieve-types:
 	@echo ""

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "metalsmith-stylus": "^2.0.0",
     "metalsmith-templates": "^0.7.0",
     "metalsmith-watch": "^1.0.1",
-    "pryv-service-core": "git+ssh://git@github.com:pryv/service-core.git#release-1.1",
+    "pryv-service-core": "file:dependencies/core",
     "pryv-style": "git://github.com/pryv/style.git",
     "unix-timestamp": "^0.2.0",
     "rec-la": "git+https://github.com/pryv/rec-la.git"

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,11 +424,9 @@ debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@*, debug@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.0.0.tgz#89bd9df6732b51256bc6705342bba02ed12131ef"
-  dependencies:
-    ms "0.6.2"
+debug@*, "debug@>= 0.7.3 < 1", debug@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-0.8.1.tgz#20ff4d26f5e422cb68a1bacbbb61039ad8c1c130"
 
 debug@0.7.4, debug@~0.7.4:
   version "0.7.4"
@@ -444,15 +442,17 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-"debug@>= 0.7.3 < 1", debug@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-0.8.1.tgz#20ff4d26f5e422cb68a1bacbbb61039ad8c1c130"
-
 debug@~1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/debug/-/debug-1.0.5.tgz#f7241217430f99dec4c2b473eab92228e874c2ac"
   dependencies:
     ms "2.0.0"
+
+debug@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.0.0.tgz#89bd9df6732b51256bc6705342bba02ed12131ef"
+  dependencies:
+    ms "0.6.2"
 
 delayed-stream@0.0.5:
   version "0.0.5"
@@ -1413,9 +1413,8 @@ proxy-addr@~2.0.2:
     forwarded "~0.1.2"
     ipaddr.js "1.5.2"
 
-"pryv-service-core@git+ssh://git@github.com:pryv/service-core.git#release-1.1":
+"pryv-service-core@file:dependencies/core":
   version "1.1.8"
-  resolved "git+ssh://git@github.com/pryv/service-core.git#6dab276460915c91ea4930adbeaf599515c9c4d6"
   dependencies:
     async "^1.4.2"
     axon "2.0.x"


### PR DESCRIPTION
Fix #36.

By cloning service-core in setup script and use local dependency in package.json (with file:).
Introduce a setup option (with default value) that allows to specify a branch for service-core.
Augment README with details about service-core dependency.