### PR TITLE
Fix/attachments doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you want to use another branch, use `make setup core=my_branch` instead.
 - `make watch` watches the source folder and rebuilds on changes
 - `make clean` cleans up the `build` folder (not done by build/watch)
 - `make publish` builds and publishes the website
-- `npm run webserver` to see the site on [https://l.rec.la:4443/](https://l.rec.la:4443/)
+- `yarn webserver` to run the site locally on [https://l.rec.la:4443/](https://l.rec.la:4443/)
 
 (Read `makefile` for details.)
 

--- a/source/_reference/examples/events.coffee
+++ b/source/_reference/examples/events.coffee
@@ -3,6 +3,14 @@ generateId = require("cuid")
 accesses = require("./accesses")
 streams = require("./streams")
 
+generateReadToken = () ->
+  hash = "";
+  dictionnary = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  for i in [1 .. 27]
+    hash += dictionnary.charAt(Math.floor(Math.random() * dictionnary.length));
+  return generateId() + '-' + hash
+
 module.exports =
   activity:
     id: generateId()
@@ -42,7 +50,7 @@ module.exports =
       fileName: "travel-expense.jpg"
       type: "image/jpeg"
       size: 1111
-      readToken: "cikxpta3r0hdw1fyq62e7nrdw-FU1y6RpJMHiidf2cyDYr4aC3AYc"
+      readToken: generateReadToken()
     ]
     created: timestamp.now()
     createdBy: accesses.app.id
@@ -154,6 +162,7 @@ module.exports =
       fileName: "photo.jpg"
       type: "image/jpeg"
       size: 2561
+      readToken: generateReadToken()
     ]
     created: timestamp.now('-1h')
     createdBy: accesses.shared.id

--- a/source/_reference/examples/events.coffee
+++ b/source/_reference/examples/events.coffee
@@ -42,6 +42,7 @@ module.exports =
       fileName: "travel-expense.jpg"
       type: "image/jpeg"
       size: 1111
+      readToken: "cikxpta3r0hdw1fyq62e7nrdw-FU1y6RpJMHiidf2cyDYr4aC3AYc"
     ]
     created: timestamp.now()
     createdBy: accesses.app.id

--- a/source/_reference/methods.coffee
+++ b/source/_reference/methods.coffee
@@ -432,7 +432,7 @@ module.exports = exports =
           key: "update"
           type: "object"
           http:
-            text: "= request body"
+            text: "request body"
           description: """
                        New values for the event's fields: see [event](##{dataStructure.getDocId("event")}). All fields are optional, and only modified values must be included.
                        """
@@ -496,7 +496,7 @@ module.exports = exports =
                        """
         ,
           key: "file"
-          type: "string"
+          type: "binary",
           http:
             text: "set as multipart/form-data"
           description: """
@@ -531,7 +531,9 @@ module.exports = exports =
       httpOnly: true
       http: "GET /events/{id}/{fileId}[/{fileName}]"
       description: """
-                   Gets the attached file. Accepts an arbitrary filename path suffix (ignored) for easier link creation.
+                   Fetches the attached file.
+                   If you use it with the authentication token passed in headers, the filename is not mandatory.
+                   When used with the readToken (for easier sharing), the filename is mandatory.
                    """
       params:
         properties: [
@@ -562,6 +564,9 @@ module.exports = exports =
         ,
           key: "readToken"
           type: "string"
+          optional: true
+          http:
+            text: "set in request path"
           description: """
                        The file read token to authentify the request if not using the `Authorization` HTTP header. See [`event.attachments[].readToken`](##{dataStructure.getDocId("event")}) for more info.
                        """

--- a/source/_reference/methods.coffee
+++ b/source/_reference/methods.coffee
@@ -514,7 +514,7 @@ module.exports = exports =
       http: "GET /events/{id}/{fileId}[/{fileName}]"
       description: """
                    Gets the attached file. Accepts an arbitrary filename path suffix (ignored) for easier link readability.
-                   For this function using the `auth` query parameter is not accepted. You can either use the [access token](##{dataStructure.getDocId("access")}) in the `Authorization` header or provide the `readToken` query parameter.
+                   For this function using the `auth` query parameter is not accepted. You can either use the [access token](##{dataStructure.getDocId("access")}) in the `Authorization` header or provide the `readToken` as query parameter.
                    """
       params:
         properties: [

--- a/source/_reference/methods.coffee
+++ b/source/_reference/methods.coffee
@@ -500,7 +500,15 @@ module.exports = exports =
           http:
             text: "set as multipart/form-data"
           description: """
-                       The name of the file (binary) to upload.
+                       The file to upload.
+                       """
+        ,
+          key: "type"
+          type: "string"
+          http:
+            text: "set as multipart/form-data"
+          description: """
+                       The type of file.
                        """
         ]
       result:
@@ -531,9 +539,8 @@ module.exports = exports =
       httpOnly: true
       http: "GET /events/{id}/{fileId}[/{fileName}]"
       description: """
-                   Fetches the attached file.
-                   If you use it with the authentication token passed in headers, the filename is not mandatory.
-                   When used with the readToken (for easier sharing), the filename is mandatory.
+                   Gets the attached file. Accepts an arbitrary filename path suffix (ignored) for easier link readability.
+                   For this function using the `auth` query parameter is not accepted. You can either use the [access token](##{dataStructure.getDocId("access")}) in the `Authorization` header or provide the `readToken` query parameter.
                    """
       params:
         properties: [
@@ -576,11 +583,6 @@ module.exports = exports =
         description: """
                      The file's content.
                      """
-      examples: [
-        params:
-          readToken: examples.events.activityAttachment.attachments[0].readToken
-      ]
-
     ,
 
       id: "events.deleteAttachment"

--- a/source/_reference/methods.coffee
+++ b/source/_reference/methods.coffee
@@ -496,11 +496,11 @@ module.exports = exports =
                        """
         ,
           key: "file"
-          type: "filename"
+          type: "string"
           http:
             text: "set as multipart/form-data"
           description: """
-                       The file (binary) to upload.
+                       The name of the file (binary) to upload.
                        """
         ]
       result:

--- a/source/_reference/methods.coffee
+++ b/source/_reference/methods.coffee
@@ -485,6 +485,16 @@ module.exports = exports =
       description: """
                    Adds one or more file attachments to the event. This request expects standard multipart/form-data content, with all content parts being the attached files.
                    """
+      params:
+        properties: [
+          key: "file"
+          type: "filename"
+          http:
+            text: "set as multipart/form-data"
+          description: """
+                       The file (binary) to upload.
+                       """
+        ]
       result:
         http: "200 OK"
         properties: [
@@ -498,9 +508,11 @@ module.exports = exports =
         title: "cURL"
         content: """
                  ```bash
-                 curl -i -F "file=@{filename}" https://${username}.pryv.me/events/#{examples.events.picture.id}?auth=${token}
+                 curl -i -F "file=@travel-expense.jpg" https://${username}.pryv.me/events/#{examples.events.activityAttachment.id}?auth=${token}
                  ```
                  """
+        result:
+          event: examples.events.activityAttachment
       ]
 
     ,

--- a/source/_reference/methods.coffee
+++ b/source/_reference/methods.coffee
@@ -536,10 +536,11 @@ module.exports = exports =
       result:
         http: "200 OK"
         description: """
-                     The file's contents.
+                     The file's content.
                      """
       examples: [
-
+        params:
+          readToken: examples.events.activityAttachment.attachments[0].readToken
       ]
 
     ,

--- a/source/_reference/methods.coffee
+++ b/source/_reference/methods.coffee
@@ -571,11 +571,10 @@ module.exports = exports =
         ,
           key: "readToken"
           type: "string"
-          optional: true
           http:
             text: "set in request path"
           description: """
-                       The file read token to authentify the request if not using the `Authorization` HTTP header. See [`event.attachments[].readToken`](##{dataStructure.getDocId("event")}) for more info.
+                       Required if not using the `Authorization` HTTP header. The file read token to authentify the request. See [`event.attachments[].readToken`](##{dataStructure.getDocId("event")}) for more info.
                        """
         ]
       result:

--- a/source/_reference/methods.coffee
+++ b/source/_reference/methods.coffee
@@ -485,32 +485,6 @@ module.exports = exports =
       description: """
                    Adds one or more file attachments to the event. This request expects standard multipart/form-data content, with all content parts being the attached files.
                    """
-      params:
-        properties: [
-          key: "id"
-          type: "[identifier](##{dataStructure.getDocId("identifier")})"
-          http:
-            text: "set in request path"
-          description: """
-                       The id of the event.
-                       """
-        ,
-          key: "file"
-          type: "binary",
-          http:
-            text: "set as multipart/form-data"
-          description: """
-                       The file to upload.
-                       """
-        ,
-          key: "type"
-          type: "string"
-          http:
-            text: "set as multipart/form-data"
-          description: """
-                       The type of file.
-                       """
-        ]
       result:
         http: "200 OK"
         properties: [
@@ -544,31 +518,6 @@ module.exports = exports =
                    """
       params:
         properties: [
-          key: "id"
-          type: "[identifier](##{dataStructure.getDocId("identifier")})"
-          http:
-            text: "set in request path"
-          description: """
-                       The id of the event.
-                       """
-        ,
-          key: "fileId"
-          type: "[identifier](##{dataStructure.getDocId("identifier")})"
-          http:
-            text: "set in request path"
-          description: """
-                       The id of the attached file.
-                       """
-        ,
-          key: "fileName"
-          type: "string"
-          optional: true
-          http:
-            text: "set in request path"
-          description: """
-                       The name of the file.
-                       """
-        ,
           key: "readToken"
           type: "string"
           http:

--- a/source/_reference/methods.coffee
+++ b/source/_reference/methods.coffee
@@ -487,6 +487,14 @@ module.exports = exports =
                    """
       params:
         properties: [
+          key: "id"
+          type: "[identifier](##{dataStructure.getDocId("identifier")})"
+          http:
+            text: "set in request path"
+          description: """
+                       The id of the event.
+                       """
+        ,
           key: "file"
           type: "filename"
           http:
@@ -527,6 +535,31 @@ module.exports = exports =
                    """
       params:
         properties: [
+          key: "id"
+          type: "[identifier](##{dataStructure.getDocId("identifier")})"
+          http:
+            text: "set in request path"
+          description: """
+                       The id of the event.
+                       """
+        ,
+          key: "fileId"
+          type: "[identifier](##{dataStructure.getDocId("identifier")})"
+          http:
+            text: "set in request path"
+          description: """
+                       The id of the attached file.
+                       """
+        ,
+          key: "fileName"
+          type: "string"
+          optional: true
+          http:
+            text: "set in request path"
+          description: """
+                       The name of the file.
+                       """
+        ,
           key: "readToken"
           type: "string"
           description: """


### PR DESCRIPTION
Fixes https://trello.com/c/HZWs5iM4

Documentation was missing some examples for Attachments, especially how to do a get query and how the result of adding an attachment to an event looks like.

Remaining questions: 
* Should we add examples for add raw/socket.io query?
* Not sure about add parameters, how to provide the file?
See: http://api.pryv.com/reference/#data-structure-event
And: https://github.com/pryv/lib-javascript/blob/master/source/connection/ConnectionEvents.js#L353