### PR TITLE
correct example delete-user

### DIFF
--- a/source/_reference/admin.coffee
+++ b/source/_reference/admin.coffee
@@ -112,7 +112,7 @@ module.exports = exports =
         id: "users.delete"
         type: "method"
         title: "Delete user"
-        http: "DELETE /platform-users/:username"
+        http: "DELETE /platform-users/{username}"
         httpOnly: true
         description: """
                     Delete user account from the Pryv.io platform. **This deletion is final**.


### PR DESCRIPTION
the example in cURL is fixed, @perki is fixing the REST Payload example by making the payload empty for get and delete calls