### PR TITLE
Customer docs: subject-side account backup (DSAR / portability) — CLI + new webapp

### DIFF
--- a/metalsmith-plugins/linkcheck.js
+++ b/metalsmith-plugins/linkcheck.js
@@ -4,6 +4,8 @@
  * Not published back to the community because it's a quickfix and we don't want further responsibilities.
  */
 
+/* global fetch, AbortController */
+
 const path = require('path');
 const fs = require('fs');
 const async = require('async');

--- a/src/customer-resources/backup.md
+++ b/src/customer-resources/backup.md
@@ -6,7 +6,7 @@ customer: true
 withTOC: true
 ---
 
-This guide describes how to back up a Pryv.io platform and how to restore from a backup.
+This guide describes how the **operator** backs up a Pryv.io platform and restores from a backup — the disaster-recovery / migration story. For the **subject-facing** backup tools (what to point a data subject at when they file a DSAR / portability request), see [Subject Account Backup](./subject-account-backup).
 
 > **Since v2 (2026)** Pryv.io ships a built-in backup/restore tool, `bin/backup.js`. Prefer it over raw database dumps — it understands Pryv.io's data model, backs up per user, supports incremental runs and can verify integrity on restore. Raw database/filesystem dumps are still documented below as a disaster-recovery alternative for operators who need them (offline DB snapshots, block-level volume backups, etc.).
 

--- a/src/customer-resources/subject-account-backup.md
+++ b/src/customer-resources/subject-account-backup.md
@@ -1,0 +1,107 @@
+---
+id: subject-account-backup
+title: 'Subject Account Backup (DSAR / Portability)'
+layout: default.pug
+customer: true
+withTOC: true
+---
+
+This guide describes the **subject-facing** backup tools — what an operator points a data subject at when they file a right-of-access (GDPR Art.15), portability (Art.20), or equivalent (CCPA §1798.110, PIPEDA Principle 4.9, Swiss nLPD Art.25, HIPAA-privacy §164.524) disclosure request. These are distinct from the operator-side disaster-recovery [`bin/backup.js`](./backup) tool — that runs server-side with raw storage access for the operator's own backups, while the subject-facing tools run against the public API as the subject themself.
+
+## Two flavors, one library
+
+Both flavors use the same underlying library and produce a portable account dump suitable for handing to the subject:
+
+- **CLI** — [`pryv-account-backup`](https://github.com/pryv/pryv-account-backup). Subjects (or implementers acting on a subject's behalf) clone the repo, `npm install`, run `npm start`. Useful for technical subjects, scripted batch exports, and any environment where binary data matters (attachments, HFS series, webhook configurations, sha256 integrity manifest).
+- **Web app** — [`pryv-account-backup-webapp`](https://github.com/pryv/pryv-account-backup-webapp). Static site you deploy on your domain. Subjects log in via a web form, click **Start backup**, download a series of ZIP files. Minimum-friction for non-technical subjects; covers the read-side text resources.
+
+Both flavors are git-clone-distributed — neither is on the npm registry. Pin to a tagged release via `github:pryv/<repo>#<tag>` in your fork's `package.json`.
+
+## What's in a bundle
+
+Per-user backup output (CLI writes to a folder; webapp writes to a series of ZIP files):
+
+| Resource | CLI | Web app | Notes |
+|---|:-:|:-:|---|
+| Account info | ✅ | ✅ | `account.json` — username, language, system-streams account tree |
+| Streams hierarchy | ✅ | ✅ | `streams.json` (`?state=all` if trashed data included) |
+| Accesses (current) | ✅ | ✅ | `accesses.json` |
+| Accesses (deletions + expired) | ✅ | ✅ | `accesses-all.json` — full disclosure-history view for Art.15(1)(c) |
+| Profile (private + public) | ✅ | ✅ | `profile_private.json` / `profile_public.json` |
+| Per-app profiles | ✅ | ✅ | `app_profiles/profile_app_<accessId>.json` per `app`-type access |
+| Audit log | ✅ | ✅ | `audit_logs.json` — fetched via the standard events API on the `:_audit:*` store streams |
+| Events (initial run) | ✅ | ✅ | `events-YYYY-MM.json` — one per UTC month in the discovered range |
+| Events (incremental run) | ✅ | ✅ | `events-incremental-<TS>.json` — only events `modified > T` |
+| Per-access version history (opt-in) | ✅ | ✅ | `accesses-history/<accessId>.json` per access |
+| Attachments (opt-in) | ✅ | ❌ | `attachments/<eventId>_<filename>` — binary streams; webapp omits to keep the bundle subject-portable |
+| High-frequency series data | ✅ | ❌ | `hf-data/<eventId>.json` per `series:*` event |
+| Webhooks per access | ✅ | ❌ | `webhooks.json` aggregated by `accessId` |
+| sha256 integrity manifest | ✅ | ❌ | `manifest.json` — tamper-evidence for third-party auditors |
+
+The webapp's coverage is the read-side text resources + their incremental story. If the subject's account uses attachments, HFS series, or has webhooks, point them at the CLI; otherwise the webapp is the more ergonomic path.
+
+## Incremental backup
+
+Both flavors persist a small state object after each successful run:
+
+- CLI: `.state.json` sentinel in the backup directory.
+- Web app: `localStorage` keyed by the subject's apiEndpoint.
+
+On the next run, the tool fetches only events + audit rows with `modified > T` where `T` is the previous `runStartedAt`. Small resources (accesses, streams, profile, webhooks) are full-re-fetched each run because their payloads are small. Binary outputs (attachments, HFS, webapp ZIPs) skip on file-presence.
+
+## Audit log handling
+
+Audit is a regular `@pryv/datastore` mounted at the `:_audit:*` store prefix on every Pryv core. The backup tools query audit via the standard events API:
+
+```
+GET /events?streams=[":_audit:accesses",":_audit:actions"]&modifiedSince=T&includeDeletions=true
+```
+
+The output filename `audit_logs.json` and content shape are stable across v0.4.0+ — third-party consumers that keyed on the file path continue to work.
+
+This route is forward-compatible with the upcoming removal of the dedicated `/audit/logs` route from open-pryv.io. Older backup-tool versions that call the dedicated route directly will silently produce empty `audit_logs.json` files once the removal lands; **upgrade subject-side tooling to v0.6.0+ before that happens.**
+
+## Operator security note
+
+The bundle carries `profile_private.json`, which includes the subject's MFA recovery codes (`profile.mfa.recoveryCodes` — 10 SMS-bypass tokens) when MFA is enabled. **Treat downloaded bundles as a secret on par with a password-reset link.** Transport over a secure channel; document destruction policy; consider asking the subject to rotate MFA recovery codes after the disclosure is complete.
+
+This applies to BOTH the CLI and webapp output. The recovery codes ride verbatim because the subject is entitled to their full MFA state — but a leaked bundle becomes a MFA-bypass vector.
+
+## MFA-enabled subjects
+
+The webapp does **not** handle MFA challenges. If the subject has MFA enabled, point them at the CLI flavor — the CLI inherits MFA handling from lib-js's `Service.login` SMS-challenge flow.
+
+## Deploy the web app
+
+```bash
+git clone https://github.com/pryv/pryv-account-backup-webapp.git
+cd pryv-account-backup-webapp
+npm install
+npm run build              # produces dist/
+```
+
+Serve `dist/` from any static HTTP server **on the same origin as the Pryv API** (or with CORS configured for cross-origin access). For local development:
+
+```bash
+npm run serve              # esbuild dev server at http://127.0.0.1:8080
+```
+
+Production deployment is a static-file copy — no backend, no Express, no Docker.
+
+## CLI walkthrough
+
+```bash
+git clone https://github.com/pryv/pryv-account-backup.git
+cd pryv-account-backup
+npm install
+npm start
+```
+
+The CLI prompts for service-info URL, username, password, trashed-data inclusion, attachments inclusion, events chunk size, per-access version history inclusion. The output lands in `./backup/<apiEndpoint>/`. Restore via `npm run restore <path-to-backup-directory>` (marked experimental — audit / webhooks / accesses are deliberately not replayed).
+
+## Related
+
+- Operator-side disaster-recovery backup: [`bin/backup.js`](./backup).
+- Library + CLI source: [`pryv-account-backup`](https://github.com/pryv/pryv-account-backup) + its `AGENTS.md`.
+- Sample web app: [`pryv-account-backup-webapp`](https://github.com/pryv/pryv-account-backup-webapp) + its `AGENTS.md`.
+- Previous-generation operator-hosted backup service (archived): [`pryv/example-service-bluebutton`](https://github.com/pryv/example-service-bluebutton). Superseded by the webapp.


### PR DESCRIPTION
## Summary

Adds [`customer-resources/subject-account-backup.md`](src/customer-resources/subject-account-backup.md) documenting the subject-facing backup tools an operator points data subjects at when they file a DSAR / portability request:

- **CLI** — [`pryv-account-backup`](https://github.com/pryv/pryv-account-backup)
- **Web app** — [`pryv-account-backup-webapp`](https://github.com/pryv/pryv-account-backup-webapp) (new in this release; replaces the now-archived `pryv/example-service-bluebutton`)

The existing operator-side [`backup.md`](src/customer-resources/backup.md) (= `bin/backup.js` disaster-recovery doc) gets a top-of-page cross-link so operators land on the right page.

### What's in the new doc

- Two flavors, one library — when to point a subject at the CLI vs the webapp.
- Per-resource matrix (CLI ✅ / webapp ✅ or ❌) so operators know what each flavor produces.
- Incremental backup model (state persistence + `modifiedSince` fetch).
- Audit-log handling via the standard events API on `:_audit:*` streams — forward-compatible with the upcoming removal of the dedicated `/audit/logs` route from open-pryv.io. Older subject-side tooling that calls `/audit/logs` directly will silently produce empty `audit_logs.json` files once the removal lands.
- Operator security note about `profile.mfa.recoveryCodes` shipping in the bundle.
- MFA-enabled subjects: point at CLI, webapp does not handle challenges.
- Deploy + walkthrough for both flavors.

### Pre-commit lint fix bundled

`metalsmith-plugins/linkcheck.js` (touched in [`18296e4`](https://github.com/pryv/dev-site/commit/18296e4) — the `request` → native fetch shim) didn't declare `fetch` + `AbortController` as eslint globals, so the pre-commit lint hook was failing on every branch. Added the `/* global fetch, AbortController */` directive.

## Test plan

- [x] Pre-commit lint passes.
- [x] No internal-ref hits: `git diff master | grep -E "Plan[- ][0-9]+|_plans/|_claude-memory|macroPryv"` → 0 hits.
- [ ] Reviewer: build the site locally + confirm `customer-resources/subject-account-backup` renders + appears in the nav.
- [ ] Reviewer: check the cross-link from `backup.md` reads correctly.