### PR TITLE
docs(reference): home-core redirect for get-username-from-email

### DIFF
--- a/src/_reference/system.coffee
+++ b/src/_reference/system.coffee
@@ -549,6 +549,8 @@ module.exports = exports =
         server: "register"
         description: """
                     Get the username of a Pryv.io account according to the given email. This API method can be disabled in the [platform configuration](https://pryv.github.io/reference-admin/#platform-settings).
+
+                    On multi-node platforms that store identifiers pseudonymised, a node that does not host the requested account answers with a `307` redirect to the account's home node — the home node URL is also returned in a `{ "server": "<url>" }` JSON body for clients that do not follow redirects automatically. The home node resolves and returns the username. Clients that follow redirects (including the official libraries) handle this transparently; single-node platforms answer directly without a redirect.
                     """
         params:
           properties: [


### PR DESCRIPTION
## Summary
- Documents the multi-node behaviour of `GET /{email}/username`: on platforms that store identifiers pseudonymised, a node that does not host the account answers `307` (with the home-node URL in a `{ "server": "<url>" }` body) and the home node returns the username.
- Clients that follow redirects (including the official libraries) handle it transparently; single-node platforms answer directly with no redirect.

## Test plan
- [ ] `just build` renders `reference-system` without errors
- [ ] rendered "Get username from email" section shows the redirect note